### PR TITLE
libibverbs: Align memory barriers to be same as kernel for Power9

### DIFF
--- a/include/infiniband/arch.h
+++ b/include/infiniband/arch.h
@@ -90,7 +90,7 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 #elif defined(__PPC64__)
 
 #define mb()	 asm volatile("sync" ::: "memory")
-#define rmb()	 asm volatile("lwsync" ::: "memory")
+#define rmb()	 asm volatile("sync" ::: "memory")
 #define wmb()	 rmb()
 #define wc_wmb() mb()
 #define nc_wmb() mb()


### PR DESCRIPTION
wmb() is mapped to rmb() to lwsync instruction in user space.
wmb() is mapped to 'sync' instruction in kernel space.

On Power9 system this resulted into partial stores in user space
application. One issue on Power9 was discovered where WQE of a QP
contained partial WQE. This fix avoids such partial stores.

This fix aligns code to use lsync for read and write barrier, similar to
what kernel does and similar to mmio_write done in recent rdma-core.

Signed-off-by: Parav Pandit <parav@mellanox.com>